### PR TITLE
Descending order was added with array inversion

### DIFF
--- a/src/components/KenticoVersionsSelector.vue
+++ b/src/components/KenticoVersionsSelector.vue
@@ -32,7 +32,10 @@ export default class KenticoVersionsSelector extends Vue {
   private isOpen = false;
 
   get kenticoVersions() {
-    return [KENTICO_VERSION_ALL_VERSIONS, ...store.getters.kenticoVersions];
+    let version = [...store.getters.kenticoVersions];
+    version.reverse().unshift(KENTICO_VERSION_ALL_VERSIONS)
+    return version;
+    //return [KENTICO_VERSION_ALL_VERSIONS, version.reverse()];
   }
 
   get selectedKenticoVersion() {


### PR DESCRIPTION
### Motivation
Fixes #7 

The descending order was added with the inversion of the array "array.reverse ()" and array.reverse (). Unshift (KENTICO_VERSION_ALL_VERSIONS) was used to put the first position