### PR TITLE
Migrate from Travis to GHActions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm i
+    - run: npm run test:unit
+    - run: build:ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,4 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm i
     - run: npm run test:unit
-    - run: build:ci
+    - run: npm run build:ci

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kentico EMS Extension Marketplace
 
-[![Build Status](https://api.travis-ci.com/Kentico/ems-extension-marketplace.svg?branch=master)](https://travis-ci.com/Kentico/ems-extension-marketplace)
+[![Build](https://github.com/Kentico/ems-extension-marketplace/actions/workflows/test.yml/badge.svg)](https://github.com/Kentico/ems-extension-marketplace/actions/workflows/test.yml)
 [![Live](https://img.shields.io/badge/Live-brightgreen.svg)](https://devnet.kentico.com/)
 [![Maintainability](https://api.codeclimate.com/v1/badges/54b3d5094d76ef66d0b4/maintainability)](https://codeclimate.com/github/Kentico/ems-extension-marketplace/maintainability)
 


### PR DESCRIPTION
### Motivation

Since Travis builds are not running anymore, this PR adds support for running builds and tests on GitHub actions.

### Checklist

- [X] Code follows coding conventions held in this repo
- [X] Automated tests have been added
- [X] Tests are passing
- [X] Docs have been updated (if applicable)
- [X] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

